### PR TITLE
Clean up subnetting

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ This module deploys a very simple spoke VPC, with a public and a private subnet 
 ### Compatibility
 Module version | Terraform version | Controller version | Terraform provider version
 :--- | :--- | :--- | :---
+v3.0.2 | 0.13 | >=6.3 | >=0.2.18
 v3.0.1 | 0.13 | >=6.3 | >=0.2.18
 v3.0.0 | 0.13 | >=6.2 | >=0.2.17
 v2.0.0 | 0.12 | >=6.2 | >=0.2.17
@@ -67,6 +68,8 @@ single_ip_snat | false | Specify whether to enable Source NAT feature in single
 customized_spoke_vpc_routes | | A list of comma separated CIDRs to be customized for the spoke VPC routes. When configured, it will replace all learned routes in VPC routing tables, including RFC1918 and non-RFC1918 CIDRs. Example: 10.0.0.0/116,10.2.0.0/16
 filtered_spoke_vpc_routes | | A list of comma separated CIDRs to be filtered from the spoke VPC route table. When configured, filtering CIDR(s) or it’s subnet will be deleted from VPC routing tables as well as from spoke gateway’s routing table. Example: 10.2.0.0/116,10.3.0.0/16
 included_advertised_spoke_routes | | A list of comma separated CIDRs to be advertised to on-prem as Included CIDR List. When configured, it will replace all advertised routes from this VPC. Example: 10.4.0.0/116,10.5.0.0/16
+vpc_num_subnets | 2 | Number of Public/Private subnet pairs created in the VPC.
+vpc_subnet_size | 28 | Size of the Public/Private subnets in the VPC.
 
 ### Outputs
 This module will return the following outputs:

--- a/main.tf
+++ b/main.tf
@@ -7,6 +7,8 @@ resource "aviatrix_vpc" "default" {
   name                 = local.name
   aviatrix_transit_vpc = false
   aviatrix_firenet_vpc = false
+  num_of_subnet_pairs  = var.vpc_subnet_pairs
+  subnet_size          = var.vpc_subnet_size
 }
 #Spoke GW
 resource "aviatrix_spoke_gateway" "default" {

--- a/variables.tf
+++ b/variables.tf
@@ -113,6 +113,18 @@ variable "included_advertised_spoke_routes" {
   default     = ""
 }
 
+variable "vpc_subnet_pairs" {
+  description = "Number of subnet pairs created in the VPC"
+  type        = number
+  default     = 2
+}
+
+variable "vpc_subnet_size" {
+  description = "Size of each subnet cidr block in bits"
+  type        = number
+  default     = 28
+}
+
 locals {
   lower_name        = replace(lower(var.name), " ", "-")
   prefix            = var.prefix ? "avx-" : ""
@@ -121,8 +133,8 @@ locals {
   cidrbits          = tonumber(split("/", var.cidr)[1])
   newbits           = 26 - local.cidrbits
   netnum            = pow(2, local.newbits)
-  subnet            = var.insane_mode ? cidrsubnet(var.cidr, local.newbits, local.netnum - 2) : aviatrix_vpc.default.subnets[length(aviatrix_vpc.default.subnets) / 2].cidr
-  ha_subnet         = var.insane_mode ? cidrsubnet(var.cidr, local.newbits, local.netnum - 1) : aviatrix_vpc.default.subnets[length(aviatrix_vpc.default.subnets) / 2 + 1].cidr
+  subnet            = var.insane_mode ? cidrsubnet(var.cidr, local.newbits, local.netnum - 2) : aviatrix_vpc.default.public_subnets[0].cidr
+  ha_subnet         = var.insane_mode ? cidrsubnet(var.cidr, local.newbits, local.netnum - 1) : aviatrix_vpc.default.public_subnets[1].cidr
   insane_mode_az    = var.insane_mode ? "${var.region}${var.az1}" : null
   ha_insane_mode_az = var.insane_mode ? "${var.region}${var.az2}" : null
 }


### PR DESCRIPTION
Exposed num_of_subnet_pairs and subnet_size attributes for the aviatrix_vpc_resource and set some sane defaults (2 and 28, respectively).

Also updated the subnetting scheme to use the vpc public_subnets attribute.